### PR TITLE
fix: wait to stop consuming until all receiving messages are consumed

### DIFF
--- a/v1/common/broker.go
+++ b/v1/common/broker.go
@@ -118,6 +118,25 @@ func (b *Broker) StopConsuming() {
 	log.WARNING.Print("Stop channel")
 }
 
+// StopConsuming is a common part of StopConsuming
+func (b *Broker) StopRetrySQS() {
+	// Do not retry from now on
+	b.retry = false
+	// Stop the retry closure earlier
+	select {
+	case b.retryStopChan <- 1:
+		log.WARNING.Print("Stopping retry closure.")
+	default:
+	}
+}
+
+// StopConsuming is a common part of StopConsuming
+func (b *Broker) StopConsumingSQS() {
+	// Notifying the stop channel stops consuming of messages
+	close(b.stopChan)
+	log.WARNING.Print("Stop channel")
+}
+
 // GetRegisteredTaskNames returns registered tasks names
 func (b *Broker) GetRegisteredTaskNames() []string {
 	b.registeredTaskNames.RLock()

--- a/v1/common/broker_test.go
+++ b/v1/common/broker_test.go
@@ -72,3 +72,33 @@ func TestStopConsuming(t *testing.T) {
 		}
 	})
 }
+
+func TestStopRetryingSQS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stop retrying sqs", func(t *testing.T) {
+		broker := common.NewBroker(&config.Config{
+			DefaultQueue: "queue",
+		})
+		broker.StartConsuming("", 1, &machinery.Worker{})
+		broker.StopRetrySQS()
+		assert.Equal(t, false, broker.GetRetry())
+	})
+}
+
+func TestStopConsumingSQS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stop consuming sqs", func(t *testing.T) {
+		broker := common.NewBroker(&config.Config{
+			DefaultQueue: "queue",
+		})
+		broker.StartConsuming("", 1, &machinery.Worker{})
+		broker.StopConsumingSQS()
+		select {
+		case <-broker.GetStopChan():
+		default:
+			assert.Fail(t, "still blocking")
+		}
+	})
+}


### PR DESCRIPTION
`stopConsuming` function will not stop consuming until all the messages are received and passed into the consuming process.
https://github.com/tomo25/machinery/blob/eb274283cbd633e928d4f19d858f8264562bd592/v1/brokers/sqs/sqs.go#L113

`StopConsumingSQS` is called after all the messages are received, so the goroutine defined in the `consumeDeliveries` function will finish after all the received messages are consumed.
https://github.com/tomo25/machinery/blob/eb274283cbd633e928d4f19d858f8264562bd592/v1/brokers/sqs/sqs.go#L306